### PR TITLE
Integrated the TabBar into the main app

### DIFF
--- a/BabbleBuddyApp/BabbleBuddyApp/MainApp/DI/DependencyInitializer.swift
+++ b/BabbleBuddyApp/BabbleBuddyApp/MainApp/DI/DependencyInitializer.swift
@@ -17,5 +17,17 @@ class DependencyInitializer {
         container.register(AuthViewModel.self) {
             DependencyInitializer.sharedAuthViewModel
         }
+
+        container.register(ViewLoaderViewModel.self) {
+            ViewLoaderViewModel()
+        }
+
+        container.register(HomeScreen.self) {
+            HomeScreen()
+        }
+
+        container.register(SettingsView.self) {
+            SettingsView()
+        }
     }
 }

--- a/BabbleBuddyApp/BabbleBuddyApp/MainApp/MainScreen/MainScreen.swift
+++ b/BabbleBuddyApp/BabbleBuddyApp/MainApp/MainScreen/MainScreen.swift
@@ -1,7 +1,6 @@
 import Foundation
 import SwiftUI
 import TabBar
-import BabiesList
 import UIKit
 import AuthLibrarySPM
 
@@ -16,10 +15,15 @@ struct MainScreen: View {
         @Inject var globalAuthViewModel: AuthViewModel
         return globalAuthViewModel
     }()
-
+    
+    @StateObject var viewLoaderViewModel: ViewLoaderViewModel = {
+       @Inject var viewLoaderViewModel: ViewLoaderViewModel
+        return viewLoaderViewModel
+    }()
+    
     var body: some View {
         AuthApp(authManager: authManager, authviewModel: authViewModel) { _ in
-            HomeScreen()
+            ViewLoader(viewModel: viewLoaderViewModel)
         }
         .environmentObject(authManager)
         .onAppear {

--- a/BabbleBuddyApp/BabbleBuddyApp/MainApp/Resources/BabbleBuddyAppResources.swift
+++ b/BabbleBuddyApp/BabbleBuddyApp/MainApp/Resources/BabbleBuddyAppResources.swift
@@ -8,4 +8,12 @@ extension String {
 
 enum LocalizedStringKeys {
     static let HomeScreenLabel = "HomeScreen_Label".localized
+    static let ViewLoaderLoadingLabel = "ViewLoader_Loading_Label".localized
+}
+
+enum BabbleBuddyAppResources {
+    enum TabBarViewControllerKeys: String {
+        case home
+        case settings
+    }
 }

--- a/BabbleBuddyApp/BabbleBuddyApp/MainApp/Resources/en.lproj/Localizable.strings
+++ b/BabbleBuddyApp/BabbleBuddyApp/MainApp/Resources/en.lproj/Localizable.strings
@@ -6,3 +6,5 @@
   
 */
 "HomeScreen_Label" = "Logged In";
+
+"ViewLoader_Loading_Label" = "Loading data...";

--- a/BabbleBuddyApp/BabbleBuddyApp/MainApp/ViewLoader/TabBarWrapper.swift
+++ b/BabbleBuddyApp/BabbleBuddyApp/MainApp/ViewLoader/TabBarWrapper.swift
@@ -1,0 +1,22 @@
+//
+//  TabBarWrapper.swift
+//  BabbleBuddyApp
+//
+//  Created by Trainee on 5/1/25.
+//
+
+import Foundation
+import SwiftUI
+import TabBar
+import AuthLibrarySPM
+
+struct TabBarWrapper: UIViewControllerRepresentable {
+    let viewControllers: [String: UIViewController]
+    
+    func makeUIViewController(context: Context) -> TabBarView {
+        let tabBarViewModel = TabBarViewModel(viewControllersProvider: { viewControllers })
+        return TabBarView(viewModel: tabBarViewModel)
+    }
+    
+    func updateUIViewController(_ uiViewController: TabBarView, context: Context) {}
+}

--- a/BabbleBuddyApp/BabbleBuddyApp/MainApp/ViewLoader/ViewLoader.swift
+++ b/BabbleBuddyApp/BabbleBuddyApp/MainApp/ViewLoader/ViewLoader.swift
@@ -1,0 +1,27 @@
+//
+//  ViewLoader.swift
+//  BabbleBuddyApp
+//
+//  Created by Trainee on 5/1/25.
+//
+
+import Foundation
+import SwiftUI
+
+struct ViewLoader: View {
+    private let localizedStrings = LocalizedStringKeys.self
+    @ObservedObject var viewModel: ViewLoaderViewModel
+
+    var body: some View {
+        Group {
+            if viewModel.isReady {
+                TabBarWrapper(viewControllers: viewModel.viewControllers)
+            } else {
+                ProgressView(localizedStrings.ViewLoaderLoadingLabel)
+                    .onAppear {
+                        viewModel.setViewControllers()
+                    }
+            }
+        }
+    }
+}

--- a/BabbleBuddyApp/BabbleBuddyApp/MainApp/ViewLoader/ViewLoaderViewModel.swift
+++ b/BabbleBuddyApp/BabbleBuddyApp/MainApp/ViewLoader/ViewLoaderViewModel.swift
@@ -1,0 +1,28 @@
+//
+//  ViewLoaderViewModel.swift
+//  BabbleBuddyApp
+//
+//  Created by Trainee on 5/1/25.
+//
+
+import Foundation
+import TabBar
+import UIKit
+import AuthLibrarySPM
+import SwiftUI
+
+class ViewLoaderViewModel: ObservableObject {
+    @Published var isReady: Bool = false
+    @Published var viewControllers: [String: UIViewController] = [:]
+    @Inject var homeScreen: HomeScreen
+    @Inject var settingsView: SettingsView
+    
+    func setViewControllers() {
+        let controllers: [String: UIViewController] = [
+            BabbleBuddyAppResources.TabBarViewControllerKeys.home.rawValue: UIHostingController(rootView: homeScreen),
+            BabbleBuddyAppResources.TabBarViewControllerKeys.settings.rawValue: UIHostingController(rootView: settingsView)
+        ]
+        self.viewControllers = controllers
+        self.isReady = true
+    }
+}


### PR DESCRIPTION
## Problem
The main app didn't have a tab bar integrated, so users had no way to navigate between multiple sections of the app after logging in.

## Solution
Integrated the `TabBar` module into the main app. 
Now after login, users are presented with a tab bar that currently includes:

 - A Home view
 - A Settings screen with a Logout option
 
 ## Evidence 
 
<table>
  <tr>
    <th>Image</th>
  </tr>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/5501b8e8-6ce4-4c0e-8ba1-b328df47f538" width="300"/></td>
  </tr>
</table>
