### PR TITLE
Delete unnecessary script and modify bundle identifier

### DIFF
--- a/BabbleBuddyApp/BabbleBuddyApp.xcodeproj/project.pbxproj
+++ b/BabbleBuddyApp/BabbleBuddyApp.xcodeproj/project.pbxproj
@@ -220,7 +220,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.Dionicio.BabbleBuddyApp;
+				PRODUCT_BUNDLE_IDENTIFIER = com.CincinnatiAI.BabbleBuddyApp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
@@ -249,7 +249,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.Dionicio.BabbleBuddyApp;
+				PRODUCT_BUNDLE_IDENTIFIER = com.CincinnatiAI.BabbleBuddyApp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;

--- a/DesignKit/DesignKit.xcodeproj/project.pbxproj
+++ b/DesignKit/DesignKit.xcodeproj/project.pbxproj
@@ -79,7 +79,6 @@
 				F57B50AB2D92F2A200834E68 /* Sources */,
 				F57B50AC2D92F2A200834E68 /* Frameworks */,
 				F57B50AD2D92F2A200834E68 /* Resources */,
-				F57B514A2D92FA2700834E68 /* ShellScript */,
 			);
 			buildRules = (
 			);
@@ -137,28 +136,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
-
-/* Begin PBXShellScriptBuildPhase section */
-		F57B514A2D92FA2700834E68 /* ShellScript */ = {
-			isa = PBXShellScriptBuildPhase;
-			alwaysOutOfDate = 1;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-			);
-			outputFileListPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "if [[ \"$(uname -m)\" == arm64 ]]; then\n    export PATH=\"/opt/homebrew/bin:$PATH\"\nfi\n\nif which swiftlint > /dev/null; then\n  swiftlint\nelse\n  echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
-			showEnvVarsInLog = 0;
-		};
-/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		F57B50AB2D92F2A200834E68 /* Sources */ = {


### PR DESCRIPTION
# Hotfix: Remove SwiftLint script and update bundle identifier

## Summary
This hotfix addresses two key issues to improve build stability and consistency across the app:

1. **SwiftLint script removal**: The current SwiftLint run script in the build phase prevents the app from launching. It has been removed to allow proper execution.
2. **Bundle Identifier updates**: Main module had incorrect bundle identifier, which have now been updated to reflect the proper project identifier required.

## Changes
- Removed the SwiftLint run script from affected targets
- Updated `bundleIdentifier` in:
  - BubbleBuddyApp
 