### PR TITLE
feat: add reusable EmptyStateView component for empty data states

### DIFF
--- a/DesignKit/DesignKit/Views/EmptyView.swift
+++ b/DesignKit/DesignKit/Views/EmptyView.swift
@@ -1,8 +1,66 @@
-//
-//  EmptyView.swift
-//  DesignKit
-//
-//  Created by CincinnatiAi Dallas on 6/18/25.
-//
+import SwiftUI
 
-import Foundation
+struct EmptyStateView: View {
+    let title: String
+    let message: String?
+    let image: Image?
+    let actionTitle: String?
+    let action: (() -> Void)?
+    
+    init(
+        title: String,
+        message: String? = nil,
+        image: Image? = Image(systemName: "tray"),
+        actionTitle: String? = nil,
+        action: (() -> Void)? = nil
+    )
+    {
+        self.title = title
+        self.message = message
+        self.image = image
+        self.actionTitle = actionTitle
+        self.action = action
+    }
+    var body: some View {
+        VStack{
+            if let image = image {
+                image
+                    .resizable()
+                    .scaledToFit()
+                    .frame(width: 80, height: 80)
+                    .foregroundColor(.gray.opacity(0.6))
+            }
+            Text(title)
+                .textStyle(.title)
+                .multilineTextAlignment(.center)
+            if let message = message {
+                Text(message)
+                    .textStyle(.body)
+                    .multilineTextAlignment(.center)
+                    .padding(.horizontal)
+            }
+            if let actionTitle = actionTitle, let action = action {
+                Button(actionTitle, action: action)
+                    .foregroundColor(.white)
+                    .buttonStyle(.borderedProminent)
+                    .padding(.top, 8)
+            }
+        }
+    }
+}
+#Preview {
+    Group {
+        //Simple empty view
+        EmptyStateView(
+            title: "Empty List"
+        )
+        EmptyStateView(
+            //New users
+            title: "Welcome to BabbleBuddy",
+            message: "Start by adding your baby's journal.",
+            image: Image(systemName: "person.crop.circle.badge.plus"),
+            actionTitle: "Get Started",
+            action: {}
+        )
+    }
+}

--- a/DesignKit/DesignKit/Views/EmptyView.swift
+++ b/DesignKit/DesignKit/Views/EmptyView.swift
@@ -1,18 +1,25 @@
 import SwiftUI
 
 struct EmptyStateView: View {
-    let title: String
-    let message: String?
-    let image: Image?
-    let actionTitle: String?
-    let action: (() -> Void)?
+    // MARK: - Layout Constants
+        var imageSize: CGFloat = 80
+        var cornerRadius: CGFloat = 8
+
+    // MARK: - Content
+        let title: String
+        let message: String?
+        let image: Image?
+        let actionTitle: String?
+        let action: (() -> Void)?
     
     init(
         title: String,
         message: String? = nil,
         image: Image? = Image(systemName: "tray"),
         actionTitle: String? = nil,
-        action: (() -> Void)? = nil
+        action: (() -> Void)? = nil,
+        imageSize: CGFloat = 80,
+        cornerRadius: CGFloat = 8
     )
     {
         self.title = title
@@ -20,6 +27,8 @@ struct EmptyStateView: View {
         self.image = image
         self.actionTitle = actionTitle
         self.action = action
+        self.imageSize = imageSize
+        self.cornerRadius = cornerRadius
     }
     var body: some View {
         VStack{
@@ -27,7 +36,7 @@ struct EmptyStateView: View {
                 image
                     .resizable()
                     .scaledToFit()
-                    .frame(width: 80, height: 80)
+                    .frame(width: imageSize, height: imageSize)
                     .foregroundColor(.gray.opacity(0.6))
             }
             Text(title)
@@ -43,7 +52,7 @@ struct EmptyStateView: View {
                 Button(actionTitle, action: action)
                     .foregroundColor(.white)
                     .buttonStyle(.borderedProminent)
-                    .padding(.top, 8)
+                    .padding(.top, cornerRadius)
             }
         }
     }
@@ -60,7 +69,9 @@ struct EmptyStateView: View {
             message: "Start by adding your baby's journal.",
             image: Image(systemName: "person.crop.circle.badge.plus"),
             actionTitle: "Get Started",
-            action: {}
+            action: {},
+            imageSize: 100,
+            cornerRadius: 12
         )
     }
 }

--- a/DesignKit/DesignKit/Views/EmptyView.swift
+++ b/DesignKit/DesignKit/Views/EmptyView.swift
@@ -1,0 +1,8 @@
+//
+//  EmptyView.swift
+//  DesignKit
+//
+//  Created by CincinnatiAi Dallas on 6/18/25.
+//
+
+import Foundation


### PR DESCRIPTION
### Description
This PR introduces a reusable EmptyStateView SwiftUI component for consistent handling of empty and placeholder UI states across the app for #56 

### Example Usage
![image](https://github.com/user-attachments/assets/3c921fbf-a273-443f-81bb-fa3eb995f89a)

```swift
EmptyStateView(
    title: "Your title",
    message: "Your Message",
    image: Image(systemName: "magnifyingglass"),
    actionTitle: "buttonText",
    action: { viewModel.yourAction() },
    imageSize: 100,
    cornerRadius: 12
)
