### PR TITLE
MVVM-C Migration for BabyJournalModule

### DIFF
--- a/BabbleBuddyApp/BabbleBuddyApp/MainApp/Resources/BBTabbar/TabBarScreenProvider.swift
+++ b/BabbleBuddyApp/BabbleBuddyApp/MainApp/Resources/BBTabbar/TabBarScreenProvider.swift
@@ -14,6 +14,32 @@ import NetworkingKit
 import BabyJournal
 
 public class TabBarScreenProvider {
+    static private let idToken: String = {
+        guard let token = KeychainHelper.shared.read(forKey: BabbleBuddyAppResources.KeychainKeys.idToken.rawValue) else {
+            return ""
+        }
+        return token
+    }()
+
+    static private let baseURL: String = {
+        guard let token = KeychainHelper.shared.read(
+            forKey: BabbleBuddyAppResources.KeychainKeys.baseURL.rawValue
+        ) else {
+            return ""
+        }
+        return token
+    }()
+
+    static private let networkClient = NetworkClient(token: idToken)
+
+    static private let babyService = BBABabiesServiceImplementation(
+        client: networkClient,
+        baseURL: baseURL
+    )
+
+    static private let journalService = BBAJournalService(client: networkClient, baseURL: baseURL)
+
+
     static func makeBabiesListView(userEmail: String) -> UIViewController {
         guard
             let baseURL = KeychainHelper.shared.read(forKey: BabbleBuddyAppResources.KeychainKeys.baseURL.rawValue),
@@ -41,26 +67,13 @@ public class TabBarScreenProvider {
     }
 
     static func makeJournalView() -> any View {
-        guard
-            let baseURL = KeychainHelper.shared.read(forKey: BabbleBuddyAppResources.KeychainKeys.baseURL.rawValue),
-            let idToken = KeychainHelper.shared.read(forKey: BabbleBuddyAppResources.KeychainKeys.idToken.rawValue),
-            !baseURL.isEmpty, !idToken.isEmpty
-        else {
-            let view = EmptyView()
-            return view
-        }
-
-        let networkClient = NetworkClient(token: idToken)
-        let babyService = BBABabiesServiceImplementation(
-            client: networkClient,
-            baseURL: baseURL
-        )
-        let journalService = BBAJournalService(client: networkClient, baseURL: baseURL)
-        let viewModel = BabyJournalViewModel(
-            journalService: journalService,
-            babiesService: babyService
+        let coordinator = BabyJournalViewCoordinator(
+            baseUrl: baseURL,
+            idToken: idToken,
+            babyService: babyService,
+            journalService: journalService
         )
 
-        return BabyJournalView(viewModel: viewModel)
+        return coordinator.navigateToBabyJournalView()
     }
 }

--- a/BabbleBuddyApp/BabbleBuddyApp/SceneDelegate.swift
+++ b/BabbleBuddyApp/BabbleBuddyApp/SceneDelegate.swift
@@ -9,6 +9,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
         guard let windowScene = (scene as? UIWindowScene) else { return }
         _ = DependencyInitializer()
+        // TODO: Create the App coordinator
         let mainScreen = { UIHostingController(rootView: MainScreen()) }
         let splashViewModel = SplashViewModel(mainScreen: mainScreen)
         let splashViewController = SplashViewController(splashViewModel: splashViewModel)

--- a/BabyJournal/BabyJournal.xcodeproj/project.pbxproj
+++ b/BabyJournal/BabyJournal.xcodeproj/project.pbxproj
@@ -50,6 +50,11 @@
 			path = Models;
 			sourceTree = "<group>";
 		};
+		D1F779042E3D21E70073E41C /* Coordinators */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = Coordinators;
+			sourceTree = "<group>";
+		};
 /* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -68,6 +73,7 @@
 		96B4D7562E047B56006AF33B = {
 			isa = PBXGroup;
 			children = (
+				D1F779042E3D21E70073E41C /* Coordinators */,
 				D15F92752E2082A100697D9C /* Models */,
 				D15F92622E20534D00697D9C /* Protocols */,
 				96B4D7622E047B56006AF33B /* BabyJournal */,
@@ -124,6 +130,7 @@
 				96B4D7622E047B56006AF33B /* BabyJournal */,
 				D15F92622E20534D00697D9C /* Protocols */,
 				D15F92752E2082A100697D9C /* Models */,
+				D1F779042E3D21E70073E41C /* Coordinators */,
 			);
 			name = BabyJournal;
 			packageProductDependencies = (

--- a/BabyJournal/Coordinators/BabyJournalViewCoordinator.swift
+++ b/BabyJournal/Coordinators/BabyJournalViewCoordinator.swift
@@ -1,0 +1,42 @@
+//
+//  BabyJournalViewCoordinator.swift
+//  BabyJournal
+//
+//  Created by Noel Hiram Pat Angulo on 8/1/25.
+//
+
+import DesignKit
+import BabiesListAndRegistration
+import SwiftUI
+
+public final class BabyJournalViewCoordinator: BBCoordinator {
+    private let baseUrl: String
+    private let idToken: String
+    private var viewModel: BabyJournalViewModel?
+    private let babyService: BBABabiesServiceProtocol
+    private let journalService: BabyJournalServiceProtocol
+
+    public init(baseUrl: String, idToken: String, babyService: BBABabiesServiceProtocol, journalService: BabyJournalServiceProtocol) {
+        self.baseUrl = baseUrl
+        self.idToken = idToken
+        self.babyService = babyService
+        self.journalService = journalService
+        /// For this particular case, since the tabbar contains the navigation stack and the navigationController, we just need to provide the screen to the tabbar
+        start()
+    }
+
+    public func start() {
+        viewModel = BabyJournalViewModel(
+            journalService: journalService,
+            babiesService: babyService
+        )
+    }
+
+    public func createView() {
+    }
+
+    public func navigateToBabyJournalView() -> any View {
+        guard let viewModel else { return EmptyView()}
+        return BabyJournalView(viewModel: viewModel)
+    }
+}

--- a/DesignKit/DesignKit/ArchitectureProtocols/BBCoordinator.swift
+++ b/DesignKit/DesignKit/ArchitectureProtocols/BBCoordinator.swift
@@ -1,0 +1,11 @@
+//
+//  BBCoordinator.swift
+//  DesignKit
+//
+//  Created by Noel Hiram Pat Angulo on 8/1/25.
+//
+
+public protocol BBCoordinator {
+    func start()
+    func createView()
+}


### PR DESCRIPTION
# Description

This PR migrate the only screen in the module, JournalView, to MVVM-C, a protocol was created and place it on the design kit module in order to homologate all the coordinators used in the app.
A recording is attached showing that the behavior of the feature wasn't change, it works exactly as it was before the migration.
The app needs more coordinators in order to avoid all those instances in the tabbar screen provider.

# Recordings

https://github.com/user-attachments/assets/e0a415bc-bf4f-43f6-9149-aefc8aa046d0

