### PR TITLE
Feature flag init added to sceneDelegate

### DIFF
--- a/BabbleBuddyApp/BabbleBuddyApp/SceneDelegate.swift
+++ b/BabbleBuddyApp/BabbleBuddyApp/SceneDelegate.swift
@@ -1,4 +1,5 @@
 import UIKit
+import AuthLibrarySPM
 import SplashViewModule
 import SwiftUI
 
@@ -17,6 +18,8 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         )
         
         guard let mainCoordinator else { return }
+        
+        FeatureFlags.shared.setBiometricEnabled(false)
 
         mainCoordinator.start()
 


### PR DESCRIPTION
### Description:
Implement a feature flag to temporarily hide biometric authentication options in BabbleBuddyiO due to ongoing malfunctions. This will prevent users from interacting with unreliable biometric functionality.

• Biometrics are hidden behind a feature flag.
• Flag can be toggled from parent app.
• UI reflects the absence of biometric options when disabled.


https://github.com/user-attachments/assets/c42dd2b2-5a09-45fe-a4de-b206885bc65c

